### PR TITLE
Add cross compilation scripts & config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-linux-gnu-gcc"
+

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,3 @@
 [target.x86_64-unknown-linux-gnu]
-linker = "x86_64-linux-gnu-gcc"
+linker = "x86_64-unknown-linux-gnu-gcc"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Export dir
+export/
+# Rust binaries
 target/
 
 # Godot-specific ignores

--- a/Patch Status.gdns
+++ b/Patch Status.gdns
@@ -1,12 +1,8 @@
 [gd_resource type="NativeScript" load_steps=2 format=2]
 
-[sub_resource type="GDNativeLibrary" id=1]
-entry/OSX.64 = "res://target/x86_64-apple-darwin/debug/libincremental_patch.dylib"
-entry/X11.64 = "res://target/x86_64-unknown-linux-gnu/debug/libincremental_patch.so"
-dependency/OSX.64 = [  ]
-dependency/X11.64 = [  ]
+[ext_resource path="res://incremental_patch.gdnlib" type="GDNativeLibrary" id=1]
 
 [resource]
 resource_name = "IncrPatch"
 class_name = "IncrementalPatch"
-library = SubResource( 1 )
+library = ExtResource( 1 )

--- a/Patch Status.gdns
+++ b/Patch Status.gdns
@@ -1,8 +1,10 @@
 [gd_resource type="NativeScript" load_steps=2 format=2]
 
 [sub_resource type="GDNativeLibrary" id=1]
-entry/OSX.64 = "res://target/debug/libincremental_patch.dylib"
+entry/OSX.64 = "res://target/x86_64-apple-darwin/debug/libincremental_patch.dylib"
+entry/X11.64 = "res://target/x86_64-unknown-linux-gnu/debug/libincremental_patch.so"
 dependency/OSX.64 = [  ]
+dependency/X11.64 = [  ]
 
 [resource]
 resource_name = "IncrPatch"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ So far we are only demonstrating the live loading of a PCK file.  A more complet
 [Read the planning ticket](https://github.com/Terkwood/godot-incremental-patch/issues/2).
 
 [See the official docs](https://godot-es-docs.readthedocs.io/en/latest/getting_started/workflow/export/exporting_pcks.html) for more information on Godot Engine's support for live-reloading of PCK (game payload) files.
+
+## Setting up Cross-Compilation with Mac as Host
+
+You need to run [this script](setup-mac.sh) if you want to cross-compile
+from Mac to Linux.  The SergioBenitez brew config is important.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Live loading a PCK file](https://user-images.githubusercontent.com/38859656/102728162-25e4b400-42f8-11eb-9265-a3a93e32aab1.gif)
 
-So far we are only demonstrating the live loading of a PCK file.  A more complete example of incremental patching will hopefully be delivered soon.  
+So far we are only demonstrating the live loading of a PCK file. A more complete example of incremental patching will hopefully be delivered soon.
 
 [Read the planning ticket](https://github.com/Terkwood/godot-incremental-patch/issues/2).
 
@@ -10,5 +10,5 @@ So far we are only demonstrating the live loading of a PCK file.  A more complet
 
 ## Setting up Cross-Compilation with Mac as Host
 
-You need to run [this script](setup-mac.sh) if you want to cross-compile
-from Mac to Linux.  The SergioBenitez brew config is important.
+You need to run [this script](setup-mac-build.sh) if you want to cross-compile
+from Mac to Linux. The SergioBenitez brew config is important.

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cargo build --target=x86_64-unknown-linux-gnu
+TARGET_CC=x86_64-linux-musl-gcc cargo build --target=x86_64-unknown-linux-musl
 cargo build --target=x86_64-apple-darwin

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-TARGET_CC=x86_64-linux-musl-gcc cargo build --target=x86_64-unknown-linux-musl
-cargo build --target=x86_64-apple-darwin
+cargo build --target=x86_64-unknown-linux-gnu
+#cargo build --target=x86_64-apple-darwin

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cargo build --target=x86_64-unknown-linux-gnu
-#cargo build --target=x86_64-apple-darwin
+cargo build --target=x86_64-apple-darwin

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo build --target=x86_64-unknown-linux-gnu
+cargo build --target=x86_64-apple-darwin

--- a/incremental_patch.gdnlib
+++ b/incremental_patch.gdnlib
@@ -7,9 +7,9 @@ reloadable=true
 
 [entry]
 
-OSX.64="res://target/debug/libincremental_patch.dylib"
+OSX.64="res://target/x86_64-apple-darwin/debug/libincremental_patch.dylib"
 Windows.64="res://../../target/debug/incremental_patch.dll"
-X11.64="res://../../target/debug/libincremental_patch.so"
+X11.64="res://target/x86_64-unknown-linux-gnu/debug/libincremental_patch.so"
 
 [dependencies]
 

--- a/setup-cross-compile-toolchains.sh
+++ b/setup-cross-compile-toolchains.sh
@@ -3,5 +3,4 @@
 # https://timryan.org/2018/07/27/cross-compiling-linux-binaries-from-macos.html
 
 rustup target add x86_64-unknown-linux-musl
-#rustup target add x86_64-unknown-linux-gnu
 rustup target add x86_64-apple-darwin

--- a/setup-cross-compile-toolchains.sh
+++ b/setup-cross-compile-toolchains.sh
@@ -2,5 +2,6 @@
 
 # https://timryan.org/2018/07/27/cross-compiling-linux-binaries-from-macos.html
 
-rustup target add x86_64-unknown-linux-gnu
+rustup target add x86_64-unknown-linux-musl
+#rustup target add x86_64-unknown-linux-gnu
 rustup target add x86_64-apple-darwin

--- a/setup-cross-compile-toolchains.sh
+++ b/setup-cross-compile-toolchains.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# https://timryan.org/2018/07/27/cross-compiling-linux-binaries-from-macos.html
+
+rustup target add x86_64-unknown-linux-gnu
+rustup target add x86_64-apple-darwin

--- a/setup-mac-build.sh
+++ b/setup-mac-build.sh
@@ -6,5 +6,6 @@ brew install FiloSottile/musl-cross/musl-cross
 # see https://github.com/imageworks/OpenShadingLanguage/issues/1055
 # works around an issue with wchar.h not found
 xcode-select --install
+softwareupdate --all --install --force
 open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 brew reinstall gcc

--- a/setup-mac-build.sh
+++ b/setup-mac-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# see https://stackoverflow.com/questions/52295433/c-header-file-wchar-h-not-found-using-g-macos
+# works around an issue with wchar.h not found
+xcode-select --install
+brew reinstall gcc

--- a/setup-mac-build.sh
+++ b/setup-mac-build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+brew install FiloSottile/musl-cross/musl-cross
+
 # see https://stackoverflow.com/questions/52295433/c-header-file-wchar-h-not-found-using-g-macos
+# see https://github.com/imageworks/OpenShadingLanguage/issues/1055
 # works around an issue with wchar.h not found
 xcode-select --install
+open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 brew reinstall gcc

--- a/setup-mac-build.sh
+++ b/setup-mac-build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-brew install FiloSottile/musl-cross/musl-cross
+# set up some cross compiling stuff on mac
+# https://stackoverflow.com/questions/41761485/how-to-cross-compile-from-mac-to-linux
+brew tap SergioBenitez/osxct
+brew install x86_64-unknown-linux-gnu
 
 # see https://stackoverflow.com/questions/52295433/c-header-file-wchar-h-not-found-using-g-macos
 # see https://github.com/imageworks/OpenShadingLanguage/issues/1055

--- a/setup-mac-build.sh
+++ b/setup-mac-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# You need to run this script if you're compiling from Mac to Linux
+
 # set up some cross compiling stuff on mac
 # https://stackoverflow.com/questions/41761485/how-to-cross-compile-from-mac-to-linux
 brew tap SergioBenitez/osxct


### PR DESCRIPTION
Advances #2.  This pass focuses on Mac as the cross-compile host.

Defers cross compilation config for Windows.

- [x] setup script: mac
- [x] setup script: linux
- [x] mega-cross-compile script
- [x]  ensure mac -> linux cross compile [basically works](https://timryan.org/2018/07/27/cross-compiling-linux-binaries-from-macos.html)
- [x] gdnlib configs for target rust binaries in godot